### PR TITLE
Modify separator used for constructing path

### DIFF
--- a/src/main/java/com/simbachain/SimbaConfigFile.java
+++ b/src/main/java/com/simbachain/SimbaConfigFile.java
@@ -66,15 +66,15 @@ public class SimbaConfigFile {
     }
 
     private File findFile(String root) {
-        File f = new File(String.join(File.pathSeparator, root, ENV_DOT_FILENAME));
+        File f = new File(String.join(File.separator, root, ENV_DOT_FILENAME));
         if (f.exists()) {
             return f;
         }
-        f = new File(String.join(File.pathSeparator, root, ENV_FILENAME));
+        f = new File(String.join(File.separator, root, ENV_FILENAME));
         if (f.exists()) {
             return f;
         }
-        f = new File(String.join(File.pathSeparator, root, ENV_DEFAULT));
+        f = new File(String.join(File.separator, root, ENV_DEFAULT));
         if (f.exists()) {
             return f;
         }


### PR DESCRIPTION
# Issue
Ran into a bug while trying to use the library to connect with the Blocks service. It seems that the string for loading the config dotenv file is using a colon instead of a forward slash as shown below

![image](https://github.com/SIMBAChain/libsimba4j-platform/assets/1753335/56d0717f-a27f-4448-a40e-a2bc9cba8b98)

# Approach
- Changed the `pathSeparator` to `separator` when constructing the config file path

# Testing
I was able to follow the sample code from the documentation using Java 1.8. This executed successfully when run with credentials against the sandbox environment.

```
package com.simbachain.simba.test.sandbox;

import com.simbachain.SimbaConfigFile;
import com.simbachain.auth.blocks.BlocksConfig;
import com.simbachain.simba.management.AuthenticatedUser;

public class ConfigTest {

    public static void main(String[] args) throws Exception {

        SimbaConfigFile config = new SimbaConfigFile();

        String clientId = config.getAuthClientId();
        String clientSecret = config.getAuthClientSecret();
        String authHost = config.getAuthBAseUrl();
        String host = config.getApiBaseUrl();

        BlocksConfig authConfig = new BlocksConfig(clientId, clientSecret, authHost);
        AuthenticatedUser user = new AuthenticatedUser(host, authConfig);

        System.out.println("Authenticated user: " + user.whoami());
    }

}
```